### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,28 +6,28 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-NtpPacket			KEYWORD1
-NtpServer			KEYWORD1
-ITimeSource			KEYWORD1
+NtpPacket	KEYWORD1
+NtpServer	KEYWORD1
+ITimeSource	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-leapIndicator		KEYWORD2
-versionNumber		KEYWORD2
-mode				KEYWORD2
-swapEndian			KEYWORD2
-populatePacket		KEYWORD2
-beginListening		KEYWORD2
+leapIndicator	KEYWORD2
+versionNumber	KEYWORD2
+mode	KEYWORD2
+swapEndian	KEYWORD2
+populatePacket	KEYWORD2
+beginListening	KEYWORD2
 processOneRequest	KEYWORD2
-getLastClientIP		KEYWORD2
-now					KEYWORD2
-timeRecv			KEYWORD2
+getLastClientIP	KEYWORD2
+now	KEYWORD2
+timeRecv	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-PACKET_SIZE			LITERAL1
-NTP_PORT			LITERAL1
+PACKET_SIZE	LITERAL1
+NTP_PORT	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords